### PR TITLE
Dodane hiperpovezave v tabeli

### DIFF
--- a/shiny/ui.R
+++ b/shiny/ui.R
@@ -51,19 +51,8 @@ shinyUI(fluidPage(
 ######################################################################
 
   tabPanel("Head To Head",
-           h2("Head To Head Statistics"),
-           sidebarLayout(
-           sidebarPanel(
-              uiOutput("tenisac"),
-              uiOutput("nasprotnik"),
-              uiOutput("turnir"),
-              uiOutput("toleto")
-             ),
-             mainPanel(
-             
-               DT::dataTableOutput('head')
-               )
-            )
+           uiOutput("h2hTitle"),
+           uiOutput("head2head")
   )
 )))
 


### PR DESCRIPTION
Dodal sem primer, kako dodati hiperpovezave v tabeli (#4). Žal stvar ni tako gladka, kot bi si želeli - pomagal sem si z rstudio/DT#178.

Trenutno se ob kliku na igralca prikaže stran z imenom in gumbom za vrnitev - za vsebino seveda poskrbite sami. Prav tako se trenutno vedno pokažeta tudi stolpca z letom in imenom turnirja - če ju želite odstraniti, bo najlažje, če to naredite za že pripravljeno tabelo s povezavami.
